### PR TITLE
Fix the negative image only converting 1/3 of the image

### DIFF
--- a/negative_image.c
+++ b/negative_image.c
@@ -19,8 +19,8 @@ int main()
 	      
 	  
 	// extract image height and width from imageHeader      
-        int width = *(int*)&imageHeader[18];
-        int height = *(int*)&imageHeader[22];
+        int width = *(int*)&imageHeader[18] * 3; // each pixel has 3 bytes of data (red, green and blue)
+        int height = *(int*)&imageHeader[22] * 3;
 	int bitDepth = *(int*)&imageHeader[28];
 
         int imgDataSize = width * height; // calculate image size

--- a/negative_image.c
+++ b/negative_image.c
@@ -20,7 +20,7 @@ int main()
 	  
 	// extract image height and width from imageHeader      
         int width = *(int*)&imageHeader[18] * 3; // each pixel has 3 bytes of data (red, green and blue)
-        int height = *(int*)&imageHeader[22] * 3;
+        int height = *(int*)&imageHeader[22];
 	int bitDepth = *(int*)&imageHeader[28];
 
         int imgDataSize = width * height; // calculate image size


### PR DESCRIPTION
This only modifies the negative_image.c

Currently, the width and height values are taken straight from the header, and used directly, assuming that 1 byte = 1 pixel. This results in corrupted image results, which, when viewed with a viewer handling this corruption, reveals that only 1/3 of the original image is treated and put in the result image.
The reason is that each pixel has 3 bytes, corresponding to the 3 colors of RGB.
Simply multiplying these values by 3 fixes this, allowing the memory allocations to ask for 3 times the size and treating the whole image.